### PR TITLE
ext: Handle sub-manifests correctly

### DIFF
--- a/flapjack/ext.py
+++ b/flapjack/ext.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Endless Mobile, Inc.
+# Copyright 2017, 2018 Endless Mobile, Inc.
 
 import collections
 import contextlib
@@ -161,7 +161,7 @@ def flatpak_builder(*args, check=None, distcheck=False):
     if check:
         check_index, check_module = next(
             (ix, m) for ix, m in enumerate(manifest['modules'])
-            if m['name'] == check)
+            if isinstance(m, dict) and m['name'] == check)
         testcmd = 'make distcheck' if distcheck else 'make check'
         if check_module.get('buildsystem', None) == 'meson':
             testcmd = 'ninja test'


### PR DESCRIPTION
It's possible to import sub-manifests by providing a string with the
sub-manifest's filename instead of a dict. The string would confuse
'flapjack test' because of not being indexable with string keys. This
skips strings when searching for the module to test.

https://phabricator.endlessm.com/T20618