### PR TITLE
commands: Custom prompt for flapjack shell

### DIFF
--- a/flapjack/commands.py
+++ b/flapjack/commands.py
@@ -213,10 +213,25 @@ class Shell(Command):
 
     def execute(self, args):
         ensure_dev_sdk()
+
+        env_vars = {
+            # This will be used as $PS1 if the users don't have a
+            # custom $PS1 in their .bashrc
+            'PS1': "[($FLAPJACK_PROMPT_PREFIX) \\u@\\h \\W]\\$ ",
+
+            # If the users do have a custom $PS1, it will override the
+            # previous setting.  So we export this environment
+            # variable that they can add to their custom $PS1.
+            'FLAPJACK_PROMPT_PREFIX': config.shell_prefix(),
+        }
+
+        env_vars_list = list("--env={}={}".format(_key, val)
+                             for _key, val in env_vars.items())
+
         opts = (['run', '--devel', '--command=bash',
-                 '--env=PS1={}{}'.format(config.shell_prefix(), ext.get_ps1()),
                  '--filesystem={}'.format(config.workdir())] +
-                config.shell_permissions() + [config.dev_sdk_id()])
+                config.shell_permissions() + env_vars_list +
+                [config.dev_sdk_id()])
         ext.flatpak(*opts, code=True)
         # COMPAT: unpacking non-final list supported in py3.5
 

--- a/flapjack/commands.py
+++ b/flapjack/commands.py
@@ -214,6 +214,7 @@ class Shell(Command):
     def execute(self, args):
         ensure_dev_sdk()
         opts = (['run', '--devel', '--command=bash',
+                 '--env=PS1={}{}'.format(config.shell_prefix(), ext.get_ps1()),
                  '--filesystem={}'.format(config.workdir())] +
                 config.shell_permissions() + [config.dev_sdk_id()])
         ext.flatpak(*opts, code=True)

--- a/flapjack/config.py
+++ b/flapjack/config.py
@@ -9,7 +9,7 @@ _DEFAULTS = {
     'Common': {
         'workdir': '~/flapjack',
         'checkoutdir': '${workdir}/checkout',
-        'shell_prefix': '(flapjack) ',
+        'shell_prefix': 'flapjack',
         'user_installation': 'no',
 
         'sdk_upstream': 'git://git.gnome.org/gnome-sdk-images',

--- a/flapjack/config.py
+++ b/flapjack/config.py
@@ -9,6 +9,7 @@ _DEFAULTS = {
     'Common': {
         'workdir': '~/flapjack',
         'checkoutdir': '${workdir}/checkout',
+        'shell_prefix': '(flapjack) ',
         'user_installation': 'no',
 
         'sdk_upstream': 'git://git.gnome.org/gnome-sdk-images',
@@ -72,6 +73,7 @@ def _shell_list(*args, **kw):
 
 workdir = _Getter('workdir', _string_expandtilde)
 checkoutdir = _Getter('checkoutdir', _string_expandtilde)
+shell_prefix = _Getter('shell_prefix')
 user_installation = _Getter('user_installation', _config.getboolean)
 sdk_upstream = _Getter('sdk_upstream')
 sdk_upstream_branch = _Getter('sdk_upstream_branch')

--- a/flapjack/ext.py
+++ b/flapjack/ext.py
@@ -4,7 +4,7 @@ import collections
 import contextlib
 import copy
 import json
-import os.path
+import os
 import subprocess
 
 from . import config, state, util
@@ -200,3 +200,21 @@ def flatpak_builder(*args, check=None, distcheck=False):
 
     with _BranchAllModules():
         return subprocess.call(cmdline, cwd=config.workdir())
+
+
+def get_ps1():
+    """Try to obtain the value of the $PS1 variable from the environment
+    or from the parent shell.  Fallback to a simple prompt if not
+    found.
+    """
+
+    if 'PS1' in os.environ:
+        return os.environ['PS1']
+
+    shell = os.environ.get('SHELL')
+    # The following command is known to work at least in bash and zsh:
+    if shell and os.path.basename(shell) in ['bash', 'zsh']:
+        ps1 = subprocess.check_output([shell, '-i', '-c', 'echo $PS1'])
+        ps1 = ps1.decode().replace('\n', ' ')
+        return ps1
+    return "$ "

--- a/flapjack/ext.py
+++ b/flapjack/ext.py
@@ -4,7 +4,7 @@ import collections
 import contextlib
 import copy
 import json
-import os
+import os.path
 import subprocess
 
 from . import config, state, util
@@ -207,21 +207,3 @@ def flatpak_builder(*args, check=None, distcheck=False):
 
     with _BranchAllModules():
         return subprocess.call(cmdline, cwd=config.workdir())
-
-
-def get_ps1():
-    """Try to obtain the value of the $PS1 variable from the environment
-    or from the parent shell.  Fallback to a simple prompt if not
-    found.
-    """
-
-    if 'PS1' in os.environ:
-        return os.environ['PS1']
-
-    shell = os.environ.get('SHELL')
-    # The following command is known to work at least in bash and zsh:
-    if shell and os.path.basename(shell) in ['bash', 'zsh']:
-        ps1 = subprocess.check_output([shell, '-i', '-c', 'echo $PS1'])
-        ps1 = ps1.decode().replace('\n', ' ')
-        return ps1
-    return "$ "


### PR DESCRIPTION
Add a configurable prefix prompt to shell, so the users can identify
when they are inside the shell.

For the default prompt I took Python's virtualenv.  There are escapes
needed for configparser: $$ for a single $, and \\u for a \u.

https://phabricator.endlessm.com/T20366