### PR TITLE
Install add_extensions in flapjack setup

### DIFF
--- a/flapjack/config.py
+++ b/flapjack/config.py
@@ -41,9 +41,14 @@ except FileNotFoundError:
     pass  # no config file, use all defaults
 
 
+def _default_op(*args, **kw):
+    val = _config.get(*args, **kw)
+    return val.strip() if val is not None else None
+
+
 class _Getter:
     """Helper to reduce tedium of defining a getter for every config option."""
-    def __init__(self, key, op=_config.get):
+    def __init__(self, key, op=_default_op):
         self.key = key
         self.op = op
 

--- a/flapjack/ext.py
+++ b/flapjack/ext.py
@@ -41,7 +41,7 @@ def flatpak(command, *args, output=False, code=False):
     if config.user_installation() and _takes_user_arg(command):
         user_arg = ['--user']
 
-    cmdline = (['flatpak', command] + user_arg + list(args))
+    cmdline = ['flatpak', command] + user_arg + list(args)
     if output:
         return subprocess.check_output(cmdline, universal_newlines=True)
     if code:

--- a/flapjack/ext.py
+++ b/flapjack/ext.py
@@ -19,7 +19,8 @@ def git(path, command, *args, output=False, code=False):
 
     cmdline = ['git', command] + list(args)
     if output:
-        return subprocess.check_output(cmdline, cwd=path)
+        return subprocess.check_output(cmdline, cwd=path,
+                                       universal_newlines=True)
     if code:
         return subprocess.call(cmdline, cwd=path)
     subprocess.check_call(cmdline, cwd=path)
@@ -42,7 +43,7 @@ def flatpak(command, *args, output=False, code=False):
 
     cmdline = (['flatpak', command] + user_arg + list(args))
     if output:
-        return subprocess.check_output(cmdline)
+        return subprocess.check_output(cmdline, universal_newlines=True)
     if code:
         return subprocess.call(cmdline)
     subprocess.check_call(cmdline)
@@ -162,7 +163,7 @@ def _branch_state(path):
                            'before building.'.format(path))
 
     rev = git(path, 'rev-parse', '--abbrev-ref', 'HEAD', output=True)
-    rev = rev.decode().strip()
+    rev = rev.strip()
 
     git(path, 'checkout', '-B', 'flapjack')
 


### PR DESCRIPTION
If there's an extension listed in the `add_extensions` config key, then we
want to install it at `flapjack setup` time. Otherwise, `flapjack build` will
immediately fail, giving a bad first experience.

Closes #15.