### PR TITLE
Add a clean-cache command

### DIFF
--- a/flapjack/commands.py
+++ b/flapjack/commands.py
@@ -4,6 +4,7 @@ import argparse
 import operator
 import os
 import os.path
+import shutil
 import subprocess
 import sys
 
@@ -318,3 +319,14 @@ class Update(Command):
         if there_were_errors:
             print('Some repositories failed to update.')
             return 1
+
+
+@register_command('clean-cache')
+class CleanCache(Command):
+    """Clean the flatpak-builder cache"""
+
+    def execute(self, args):
+        cache_dir = os.path.join(config.workdir(), '.flatpak-builder')
+        if os.path.isdir(cache_dir):
+            shutil.rmtree(cache_dir, ignore_errors=True)
+        return 0


### PR DESCRIPTION
It's useful to have a way to clean up the flatpak-builder cache, as it
has the tendency to blow up after a while.

Instead of hunting it down yourself, it's easier if we let flapjack do
it for us.