### PR TITLE
Various fixes

### DIFF
--- a/flapjack/commands.py
+++ b/flapjack/commands.py
@@ -109,12 +109,11 @@ def find_remote_for_runtime(runtime, branch):
     for candidate_remote in remotes:
         candidate_remote_name = candidate_remote[0]
         runtimes_list = ext.flatpak('remote-ls', candidate_remote_name,
-                                    '--runtime', '-d', output=True)
+                                    '--runtime', '--columns=ref', output=True)
         runtimes_list = runtimes_list.split('\n')[1:]
-        for line in runtimes_list:
-            if not line:
+        for quad in runtimes_list:
+            if not quad:
                 continue
-            quad = line.split(maxsplit=1)[0]
             candidate_id, _, candidate_branch = quad.split('/')[1:]
             if candidate_id == runtime and candidate_branch == branch:
                 return candidate_remote

--- a/flapjack/config.py
+++ b/flapjack/config.py
@@ -18,7 +18,7 @@ _DEFAULTS = {
         'sdk_manifest_json': '${sdk_id}.json.in',
         'sdk_repo_name': 'flapjack-source',
         'sdk_repo_definition':
-            'https://sdk.gnome.org/gnome-nightly.flatpakrepo',
+            'https://nightly.gnome.org/gnome-nightly.flatpakrepo',
         'dev_sdk_id': 'org.gnome.dev.Sdk',
         'add_extensions': 'org.gnome.Sdk.Docs:share/runtime/docs',
 


### PR DESCRIPTION
Fixes notwithstanding, it may be time to retire flapjack; it's not possible to use it with newer GNOME runtimes, because they don't use flatpak-builder anymore, as I discovered today while trying to build a GNOME runtime with an updated GJS inside it.